### PR TITLE
Make homebrew update optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,15 +89,6 @@ func main() {
 	fmt.Println()
 	log.SetEnableDebugLog(cfg.VerboseLog)
 
-	log.Infof("Update homebrew")
-	cmd := command.New("brew", "update").SetStdout(os.Stdout).SetStderr(os.Stderr)
-	log.Donef("$ %s", cmd.PrintableCommandArgs())
-
-	if err := cmd.Run(); err != nil {
-		fail("Can't update brew: %s", err)
-	}
-	fmt.Println()
-
 	log.Infof("Run brew command")
 	args := cmdArgs(cfg.Options, cfg.Packages, cfg.Upgrade, cfg.VerboseLog)
 	cmd = command.New("brew", args...).SetStdout(os.Stdout).SetStderr(os.Stderr)

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	log.Infof("Run brew command")
 	args := cmdArgs(cfg.Options, cfg.Packages, cfg.Upgrade, cfg.VerboseLog)
-	cmd = command.New("brew", args...).SetStdout(os.Stdout).SetStderr(os.Stderr)
+	cmd := command.New("brew", args...).SetStdout(os.Stdout).SetStderr(os.Stderr)
 
 	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Because Homebrew already supports configuration for auto-updates via the `HOMEBREW_NO_AUTO_UPDATE` environment variable, there should be no need to define a separate, external configuration for the exact same behavior. This PR removes the mandatory auto-update from this workflow step in order to enable users to opt-out of the default behavior of updating.

This PR should resolve the following open issues: 
https://github.com/bitrise-steplib/steps-brew-install/issues/12 
https://github.com/bitrise-steplib/steps-brew-install/issues/9