### PR TITLE
Optional command output setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _tmp/
+.idea
+.vscode

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func brewFileArgs(options string, verboseLog bool, path string) (args []string) 
 }
 
 func collectCache() error {
-	cmd := brewCommand([]string{"--cache"})
+	cmd := brewCommand([]string{"--cache"}, false)
 	log.Debugf("$ %s", cmd.PrintableCommandArgs())
 
 	brewCachePth, err := cmd.RunAndReturnTrimmedOutput()
@@ -100,7 +100,7 @@ func collectCache() error {
 }
 
 func cleanCache() error {
-	cmd := brewCommand([]string{"cleanup"})
+	cmd := brewCommand([]string{"cleanup"}, true)
 
 	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	if err := cmd.Run(); err != nil {
@@ -122,7 +122,7 @@ func main() {
 	log.Infof("Run brew command")
 	if cfg.UseBrewfile {
 		args := brewFileArgs(cfg.Options, cfg.VerboseLog, cfg.BrewfilePath)
-		cmd := brewCommand(args)
+		cmd := brewCommand(args, true)
 
 		log.Donef("$ %s", cmd.PrintableCommandArgs())
 		if err := cmd.Run(); err != nil {
@@ -130,7 +130,7 @@ func main() {
 		}
 	} else {
 		args := cmdArgs(cfg.Options, cfg.Packages, cfg.Upgrade, cfg.VerboseLog)
-		cmd := brewCommand(args)
+		cmd := brewCommand(args, true)
 
 		log.Donef("$ %s", cmd.PrintableCommandArgs())
 		if err := cmd.Run(); err != nil {
@@ -158,7 +158,7 @@ func main() {
 	}
 }
 
-func brewCommand(args []string) *command.Model {
+func brewCommand(args []string, setDefaultOutput bool) *command.Model {
 	brewPrefix, err := command.New("brew", "--prefix").RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		log.Warnf("Failed to get brew prefix: %s\n%s", err, brewPrefix)
@@ -184,5 +184,9 @@ func brewCommand(args []string) *command.Model {
 		effectiveArgs = args
 	}
 
-	return command.New(effectiveCmd, effectiveArgs...).SetStdout(os.Stdout).SetStderr(os.Stderr)
+	if setDefaultOutput {
+		return command.New(effectiveCmd, effectiveArgs...).SetStdout(os.Stdout).SetStderr(os.Stderr)
+	}
+
+	return command.New(effectiveCmd, effectiveArgs...)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

When working with commands the simpler ways of accessing the output like `RunAndReturnTrimmedOutput` and other set the output and error to stdout and stderr. Setting these manually will result in an error when executed. 

This PR will make the setting of the outputs optional based on how the caller wants to work with the step output.