### PR TITLE
Don't upgrade dependent packages by default

### DIFF
--- a/brew_config.go
+++ b/brew_config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -39,7 +41,8 @@ func (p brewConfigPrinter) printBrewConfig(envOverrides map[string]string) {
 func (p brewConfigPrinter) printEnv(env string, envOverrides map[string]string) {
 	var value string
 
-	if override, ok := envOverrides[env]; ok {
+	override, hasOverride := envOverrides[env]
+	if hasOverride {
 		value = override
 	} else {
 		value = p.envRepo.Get(env)
@@ -47,6 +50,8 @@ func (p brewConfigPrinter) printEnv(env string, envOverrides map[string]string) 
 
 	if value == "" {
 		value = "<unset>"
+	} else if hasOverride {
+		value = fmt.Sprintf("%s (override by step input)", colorstring.Cyan(value))
 	} else {
 		value = colorstring.Cyan(value)
 	}

--- a/brew_config.go
+++ b/brew_config.go
@@ -48,10 +48,10 @@ func (p brewConfigPrinter) printEnv(env string, envOverrides map[string]string) 
 		value = p.envRepo.Get(env)
 	}
 
-	if value == "" {
-		value = "<unset>"
-	} else if hasOverride {
+	if hasOverride {
 		value = fmt.Sprintf("%s (override by step input)", colorstring.Cyan(value))
+	} else if value == "" {
+		value = "<unset>"
 	} else {
 		value = colorstring.Cyan(value)
 	}

--- a/brew_config.go
+++ b/brew_config.go
@@ -13,7 +13,7 @@ type brewConfigPrinter struct {
 	logger     log.Logger
 }
 
-func (p brewConfigPrinter) printBrewConfig() {
+func (p brewConfigPrinter) printBrewConfig(envOverrides map[string]string) {
 	p.logger.Infof("Homebrew configuration:")
 
 	for _, env := range []string{
@@ -23,7 +23,7 @@ func (p brewConfigPrinter) printBrewConfig() {
 		"HOMEBREW_NO_AUTO_UPDATE",
 		"HOMEBREW_CORE_GIT_REMOTE",
 	} {
-		p.printEnv(env)
+		p.printEnv(env, envOverrides)
 	}
 
 	p.logger.Printf("%s: Default values are documented at https://docs.brew.sh/Manpage#environment", colorstring.Yellow("Note"))
@@ -36,8 +36,15 @@ func (p brewConfigPrinter) printBrewConfig() {
 	}
 }
 
-func (p brewConfigPrinter) printEnv(env string) {
-	value := p.envRepo.Get(env)
+func (p brewConfigPrinter) printEnv(env string, envOverrides map[string]string) {
+	var value string
+
+	if override, ok := envOverrides[env]; ok {
+		value = override
+	} else {
+		value = p.envRepo.Get(env)
+	}
+
 	if value == "" {
 		value = "<unset>"
 	} else {

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -7,6 +7,7 @@ workflows:
     - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "no"
+    - UPGRADE_DEPENDENTS: "no"
     - CACHE_ENABLED: "no"
     after_run:
     - _common
@@ -26,6 +27,7 @@ workflows:
     - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "yes"
+    - UPGRADE_DEPENDENTS: "no"
     - CACHE_ENABLED: "no"
     after_run:
     - _common
@@ -35,6 +37,7 @@ workflows:
     - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "yes"
+    - UPGRADE_DEPENDENTS: "no"
     - CACHE_ENABLED: "yes"
     after_run:
     - _common

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -16,7 +16,7 @@ workflows:
     envs:
     - PACKAGES: curl
     - OPTIONS: ""
-    - UPGRADE: "no"
+    - UPGRADE: "yes"
     - UPGRADE_DEPENDENTS: "yes"
     - CACHE_ENABLED: "no"
     after_run:
@@ -84,7 +84,6 @@ workflows:
         - upgrade: $UPGRADE
         - upgrade_dependents: $UPGRADE_DEPENDENTS
         - cache_enabled: $CACHE_ENABLED
-        - verbose_log: "yes"
 
   _change_workdir:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -3,14 +3,11 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
   test_install:
-    envs:
-    - PACKAGES: curl
-    - OPTIONS: ""
-    - UPGRADE: "no"
-    - UPGRADE_DEPENDENTS: "no"
-    - CACHE_ENABLED: "no"
-    after_run:
-    - _common
+    steps:
+    - path::./:
+        title: Test default behavior
+        inputs:
+        - packages: curl
 
   test_install_and_upgrade_dependents:
     envs:
@@ -19,8 +16,13 @@ workflows:
     - UPGRADE: "yes"
     - UPGRADE_DEPENDENTS: "yes"
     - CACHE_ENABLED: "no"
-    after_run:
-    - _common
+    steps:
+    - path::./:
+        title: Install and upgrade dependents
+        inputs:
+        - packages: curl
+        - upgrade: "yes"
+        - upgrade_dependents: "yes"
 
   test_upgrade:
     envs:
@@ -29,18 +31,21 @@ workflows:
     - UPGRADE: "yes"
     - UPGRADE_DEPENDENTS: "no"
     - CACHE_ENABLED: "no"
-    after_run:
-    - _common
+    steps:
+    - path::./:
+        title: Upgrade
+        inputs:
+        - packages: curl
+        - upgrade: "yes"
 
   test_cache:
-    envs:
-    - PACKAGES: curl
-    - OPTIONS: ""
-    - UPGRADE: "yes"
-    - UPGRADE_DEPENDENTS: "no"
-    - CACHE_ENABLED: "yes"
-    after_run:
-    - _common
+    steps:
+    - path::./:
+        title: Test cache
+        inputs:
+        - packages: curl
+        - upgrade: "yes"
+        - cache_enabled: "yes"
 
   test_bundle:
     before_run:
@@ -73,17 +78,6 @@ workflows:
         inputs:
         - use_brewfile: "yes"
         - brewfile_path: ./pathtest/Brewfile
-
-  _common:
-    steps:
-    - path::./:
-        title: Run step
-        inputs:
-        - packages: $PACKAGES
-        - options: $OPTIONS
-        - upgrade: $UPGRADE
-        - upgrade_dependents: $UPGRADE_DEPENDENTS
-        - cache_enabled: $CACHE_ENABLED
 
   _change_workdir:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -10,7 +10,7 @@ workflows:
     - CACHE_ENABLED: "no"
     after_run:
     - _common
-  
+
   test_install_and_upgrade_dependents:
     envs:
     - PACKAGES: curl

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -4,16 +4,26 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 workflows:
   test_install:
     envs:
-    - PACKAGES: fswatch
+    - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "no"
+    - CACHE_ENABLED: "no"
+    after_run:
+    - _common
+  
+  test_install_and_upgrade_dependents:
+    envs:
+    - PACKAGES: curl
+    - OPTIONS: ""
+    - UPGRADE: "no"
+    - UPGRADE_DEPENDENTS: "yes"
     - CACHE_ENABLED: "no"
     after_run:
     - _common
 
   test_upgrade:
     envs:
-    - PACKAGES: fswatch
+    - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "yes"
     - CACHE_ENABLED: "no"
@@ -22,7 +32,7 @@ workflows:
 
   test_cache:
     envs:
-    - PACKAGES: fswatch
+    - PACKAGES: curl
     - OPTIONS: ""
     - UPGRADE: "yes"
     - CACHE_ENABLED: "yes"
@@ -69,6 +79,7 @@ workflows:
         - packages: $PACKAGES
         - options: $OPTIONS
         - upgrade: $UPGRADE
+        - upgrade_dependents: $UPGRADE_DEPENDENTS
         - cache_enabled: $CACHE_ENABLED
         - verbose_log: "yes"
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -17,7 +17,7 @@ workflows:
         - packages: curl
         - upgrade: "yes"
         - upgrade_dependents: "yes"
-  
+
   test_install_and_upgrade_dependents_env_var:
     envs:
     # Stacks will soon define this env var by default.

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -10,12 +10,6 @@ workflows:
         - packages: curl
 
   test_install_and_upgrade_dependents:
-    envs:
-    - PACKAGES: curl
-    - OPTIONS: ""
-    - UPGRADE: "yes"
-    - UPGRADE_DEPENDENTS: "yes"
-    - CACHE_ENABLED: "no"
     steps:
     - path::./:
         title: Install and upgrade dependents
@@ -23,14 +17,22 @@ workflows:
         - packages: curl
         - upgrade: "yes"
         - upgrade_dependents: "yes"
+  
+  test_install_and_upgrade_dependents_env_var:
+    envs:
+    # Stacks will soon define this env var by default.
+    # Homebrew doesn't parse `HOMEBREW_ENV=0` style envs correctly,
+    # so this test is here to verify that the step can handle it.
+    - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
+    steps:
+    - path::./:
+        title: Install and upgrade dependents (env var is set)
+        inputs:
+        - packages: curl
+        - upgrade: "yes"
+        - upgrade_dependents: "yes"
 
   test_upgrade:
-    envs:
-    - PACKAGES: curl
-    - OPTIONS: ""
-    - UPGRADE: "yes"
-    - UPGRADE_DEPENDENTS: "no"
-    - CACHE_ENABLED: "no"
     steps:
     - path::./:
         title: Upgrade

--- a/main.go
+++ b/main.go
@@ -132,9 +132,10 @@ func main() {
 	extraEnvs := make(map[string]string)
 	var noDependentsCheck string
 	if cfg.UpgradeDependents {
-		noDependentsCheck = "false"
+		// Need to use `0`, `false` is parsed as `true`
+		noDependentsCheck = "0"
 	} else {
-		noDependentsCheck = "true"
+		noDependentsCheck = "1"
 	}
 	extraEnvs["HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK"] = noDependentsCheck
 	extraEnvs["HOMEBREW_COLOR"] = "true" // Gets disabled on non-TTY outputs, but we can handle it

--- a/main.go
+++ b/main.go
@@ -132,8 +132,8 @@ func main() {
 	extraEnvs := make(map[string]string)
 	var noDependentsCheck string
 	if cfg.UpgradeDependents {
-		// Need to use `0`, `false` is parsed as `true`
-		noDependentsCheck = "0"
+		// Need to use the empty string, anything else is parsed as `true`, including "0" and "false"
+		noDependentsCheck = ""
 	} else {
 		noDependentsCheck = "1"
 	}

--- a/main.go
+++ b/main.go
@@ -214,6 +214,8 @@ func brewCommand(args []string, extraEnvs map[string]string, setDefaultOutput bo
 	for k, v := range extraEnvs {
 		envStrings = append(envStrings, fmt.Sprintf("%s=%s", k, v))
 	}
+	// Go `cmd.Env` implementation detail: duplicate env vars are handled by applying the last one,
+	// so this is fine.
 	finalEnvs := append(os.Environ(), envStrings...)
 
 	if setDefaultOutput {

--- a/step.yml
+++ b/step.yml
@@ -74,9 +74,9 @@ inputs:
     title: Upgrade dependent packages
     description: |
       If set to `no`, the step won't upgrade other **installed packages** that depend on the package to be installed.
-      
+
       This helps predictability and install times, but sometimes could cause problems with existing installed packages if they are not compatible the newly installed package (Homebrew is an evergreen package manager by design). More information is available [here](https://docs.brew.sh/FAQ#why-does-brew-upgrade-formula-or-brew-install-formula-also-upgrade-a-bunch-of-other-stuff) and [here](HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK).
-      
+
       If you experience a broken package, set this input to `yes`.
 
       This input controls the `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` env var.

--- a/step.yml
+++ b/step.yml
@@ -69,6 +69,20 @@ inputs:
     value_options:
     - "yes"
     - "no"
+- upgrade_dependents: "no"
+  opts:
+    title: Upgrade dependent packages
+    description: |
+      If set to `no`, the step won't upgrade other **installed packages** that depend on the package to be installed.
+      
+      This helps predictability and install times, but sometimes could cause problems with existing installed packages if they are not compatible the newly installed package (Homebrew is an evergreen package manager by design). More information is available [here](https://docs.brew.sh/FAQ#why-does-brew-upgrade-formula-or-brew-install-formula-also-upgrade-a-bunch-of-other-stuff) and [here](HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK).
+      
+      If you experience a broken package, set this input to `yes`.
+
+      This input controls the `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` env var.
+    value_options:
+    - "yes"
+    - "no"
 - use_brewfile: "no"
   opts:
     title: Use a Brewfile to install packages?


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)

### Context

Homebrew's default behavior is to upgrade dependent packages to their latest version when I install a package. [This is a common complaint](https://github.com/Homebrew/brew/issues/9285) that won't be fixed because Homebrew is an evergreen package manager.

The CI environment is different though (I think), (stable) stacks are frozen in terms of the installed brew package versions, and only edge stacks receive weekly package upgrades.

Also, the risk of upgrading unrelated packages when installing a single package and breaking the CI workflow is probably bigger than the risk of breaking a specific package because it links to a previous version of a package.

A concrete example on an older stack:

```
brew install curl
[...]
==> Upgrading 57 dependents of upgraded formulae:
Disable this behaviour by setting HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
aom 3.7.0 -> 3.8.2, apr-util 1.6.3 -> 1.6.3_1, aria2 1.36.0_1 -> 1.37.0, awscli 2.13.25 -> 2.15.40, boost 1.82.0_1 -> 1.84.0_1, cffi 1.16.0 -> 1.16.0_1, docutils 0.20.1 -> 0.21.1, edencommon 2023.10.09.00 -> 2024.04.15.00, fbthrift 2023.10.09.00 -> 2024.04.15.00, fizz 2023.10.09.00 -> 2024.04.15.00, fb303 2023.10.09.00 -> 2024.04.15.00, folly 2023.10.09.00 -> 2024.04.15.00, freetds 1.4.2 -> 1.4.12, ghostscript 10.02.0 -> 10.03.0, git 2.40.1 -> 2.44.0, glib 2.78.0 -> 2.80.0_2, gnupg 2.4.3 -> 2.4.5, gnutls 3.8.1 -> 3.8.4, gradle 8.4 -> 8.7, groovy 4.0.15 -> 4.0.21, harfbuzz 8.2.1 -> 8.4.0, imagemagick 7.1.1-20 -> 7.1.1-31, jpeg-xl 0.8.2_1 -> 0.10.2, kotlin 1.9.10 -> 1.9.23, libassuan 2.5.6 -> 2.5.7, libavif 1.0.1 -> 1.0.4, libevent 2.1.12 -> 2.1.12_1, libgpg-error 1.47 -> 1.48, libgcrypt 1.10.2 -> 1.10.3, libheif 1.16.2 -> 1.17.6_1, libksba 1.6.4 -> 1.6.6, libpq 16.0 -> 16.2_1, little-cms2 2.15 -> 2.16, libraw 0.21.1 -> 0.21.2, llvm 17.0.2 -> 17.0.6_1, openjdk 21 -> 21.0.2, maven 3.9.5 -> 3.9.6, mercurial 6.5.2 -> 6.7.2, openjdk@11 11.0.20.1 -> 11.0.23, openjdk@17 17.0.8.1 -> 17.0.11, openjpeg 2.5.0_1 -> 2.5.2, openssl@1.1 1.1.1u -> 1.1.1w, openvpn 2.6.4 -> 2.6.10, p11-kit 0.25.0 -> 0.25.3, php 8.2.11 -> 8.3.6, pinentry 1.2.1 -> 1.3.0, pkcs11-helper 1.29.0 -> 1.30.0, pycparser 2.21 -> 2.22, pyenv 2.3.18 -> 2.4.0, python@3.11 3.11.6 -> 3.11.9, shared-mime-info 2.3 -> 2.4, unbound 1.17.1 -> 1.19.3, wangle 2023.10.09.00 -> 2024.04.15.00, watchman 2023.10.09.00 -> 2024.04.15.00, webp 1.3.2 -> 1.4.0, wget 1.21.4 -> 1.24.5, yamllint 1.32.0 -> 1.35.1
```

`curl` depends on `openssl@3`, so Homebrew updated `openssl@3` to its latest version. But because nearly everything depends on OpenSSL, Homebrew also upgraded `gradle`, `git`, `openjdk`, `php`, `python`, just to name a few important packages.

This also makes package install times unpredictable, we see a crazy difference between the p50 and p90 step run times (9 seconds vs. 155 seconds).

### Changes

- Add a new input (`upgrade_dependents`) that controls this behavior via the `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` env var
- Make the default behavior equal to `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1`
  - Note: because this step's default behavior is the inverse of Homebrew's default behavior, I decided to call the input `upgrade_dependents` with the default being `no`, so even if the step input is undefined, it's the same as the default (step) behavior. I know it makes the implementation more complicated, but it's less confusing when the input is not defined.
- This is going to be a breaking change (and a major step version)
- Tests: only E2E tests for this kind of complex thing :)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
